### PR TITLE
Supply patched functions list to the policies through the policy initializer

### DIFF
--- a/examples/policies/suse/ipa_clones.py
+++ b/examples/policies/suse/ipa_clones.py
@@ -154,10 +154,9 @@ class IpaClones:
                 spawn = add_node(Node(spawn))
 
                 edge = Edge(original, spawn, edge_type)
-                if edge in edges:
-                    next
-                edges.add(edge)
-                edge._link_to_nodes()
+                if edge not in edges:
+                    edges.add(edge)
+                    edge._link_to_nodes()
 
             elif line[0] == 'Callgraph removal':
                 if len(line) != 6:

--- a/examples/policies/suse/klp_policy.py
+++ b/examples/policies/suse/klp_policy.py
@@ -35,7 +35,7 @@ class ExternalizableSymbol:
     is_exported: bool
 
 class KlpPolicy(ccp.LpCreationPolicyAbc):
-    def __init__(self):
+    def __init__(self, patched_funcs):
         self._cfg_mod_symvers_filename = os.getenv('KCP_MOD_SYMVERS')
         if not self._cfg_mod_symvers_filename:
             raise KeyError('$KCP_MOD_SYMVERS not set')
@@ -77,17 +77,12 @@ class KlpPolicy(ccp.LpCreationPolicyAbc):
         else:
             self._cfg_ext_blacklist = set()
 
-        patched_funcs = os.getenv('KCP_FUNC')
-        if patched_funcs:
-            self._cfg_patched_funcs = set(map(lambda e: e.strip(),
-                                              patched_funcs.split(',')))
-        else:
-            self._cfg_patched_funcs = []
-
         self._cfg_work_dir = os.getenv('KCP_WORK_DIR')
         if not self._cfg_work_dir:
             raise KeyError('$KCP_WORK_DIR not set')
 
+        assert isinstance(patched_funcs, list)
+        self._cfg_patched_funcs = set(patched_funcs)
 
         self._mod_symvers = ModuleSymvers(self._cfg_mod_symvers_filename)
         self._patched_obj_elf = TargetModElf(self._cfg_patched_obj_filename)

--- a/lp_creation_python_policy.cc
+++ b/lp_creation_python_policy.cc
@@ -961,7 +961,17 @@ lp_creation_python_policy::lp_creation_python_policy
       "specified python policy class can't get instantiated"
     };
   }
-  PyObject *args = PyTuple_New(0);
+
+  // Allocate a python list with the patched functions
+  PyObject *patched_funcs_py_list = PyList_New(_patched_functions.size());
+  for (size_t i = 0; i < _patched_functions.size(); i++) {
+      PyObject *patched_func_py_str = PyUnicode_FromString(_patched_functions[i].c_str());
+      // Transfer items ownership to the list: no need to call Py_DECREF on them later on
+      PyList_SetItem(patched_funcs_py_list, i, patched_func_py_str);
+  }
+
+  PyObject *args = PyTuple_Pack(1, patched_funcs_py_list);
+  Py_DECREF(patched_funcs_py_list);
   if (!args) {
     Py_DECREF(pol_cls);
     throw python_except{


### PR DESCRIPTION
The Python policy retrieves the list of patched functions from the environment variable `KCP_FUNC`. This approach is redundant, as the same list is already passed via the command line to `klp-ccp`, requiring users to specify it twice: once for klp-ccp and again for the policy via the environment.

This patch changes the python policy API to supply the list of patched functions directly to the Policy constructor, eliminating the need for the policy to read it from the environment variable.

The `suse` example policy is adjusted accordingly.

I'm opening this PR as a draft because before merging I want to test it on more livepatches to make sure also the ipa-clones and other affected logics are working correctly after this change.