### PR TITLE
Uncompress modules

### DIFF
--- a/examples/policies/suse/klp_policy.py
+++ b/examples/policies/suse/klp_policy.py
@@ -110,13 +110,8 @@ class KlpPolicy(ccp.LpCreationPolicyAbc):
         if patched_obj_ko.startswith('vmlinux'):
             self._patched_obj_name = 'vmlinux'
         else:
-            patched_obj_ko = os.path.splitext(patched_obj_ko)
-            if patched_obj_ko[1] != '.ko':
-                raise ValueError('invalid module filename extension in \"' +
-                                 self._cfg_patched_obj_filename + '\"')
-            self._patched_obj_name = \
-                patched_obj_ko[0].translate({ord('-') : ord('_')})
-
+            patched_obj_ko = re.sub(r'(?:\.ko)?(?:\.gz|\.xz|\.zst)?$', '', patched_obj_ko)
+            self._patched_obj_name = patched_obj_ko.translate({ord("-"): ord("_")})
 
         self._re_eligible_header_filename = []
         self._re_eligible_header_filename.append(

--- a/examples/policies/suse/mod_symvers.py
+++ b/examples/policies/suse/mod_symvers.py
@@ -16,13 +16,26 @@
 # along with klp-ccp. If not, see <https://www.gnu.org/licenses/>.
 #
 
+import gzip
 import os.path
+
+import magic
+
 
 class ModuleSymvers:
     def __init__(self, filename):
-        f = open(filename)
+        # Decompress symvers file if needed
+        mime = magic.detect_from_filename(filename)
+        zipped = mime.encoding == "binary"
+
+        with open(filename, "rb" if zipped else "r") as f:
+            data = f.read()
+
+        if zipped:
+            data = gzip.decompress(data).decode()
+
         self.symvers = {}
-        for line in f:
+        for line in data.splitlines():
             line = line.strip()
             record = line.split('\t')
             if len(record) < 4 or len(record) > 5:

--- a/examples/policies/suse/target_mod_elf.py
+++ b/examples/policies/suse/target_mod_elf.py
@@ -1,9 +1,35 @@
+import gzip
+import io
+import lzma
+
+import magic
+import zstandard
 from elftools.elf.elffile import ELFFile
+
 
 class TargetModElf:
     def __init__(self, filename):
-        self._f = open(filename, 'rb')
-        self.elf = ELFFile(self._f)
+        with open(filename, 'rb') as f:
+            data = f.read()
+
+        io_bytes = None
+
+        mime = magic.detect_from_filename(filename)
+
+        if "gzip" in mime.mime_type:
+            io_bytes = io.BytesIO(gzip.decompress(data))
+        elif "zstd" in mime.mime_type:
+            dctx = zstandard.ZstdDecompressor()
+            io_bytes = io.BytesIO(dctx.decompress(data))
+        elif "x-xz" in mime.mime_type:
+            io_bytes = io.BytesIO(lzma.decompress(data))
+        # Kernel modules are x-object, while vmlinux is x-executable
+        elif "x-object" in mime.mime_type or "x-executable" in mime.mime_type:
+            io_bytes = io.BytesIO(data)
+        else:
+            raise RuntimeError(f"File {filename} with unknown format: {mime.mime_type}")
+
+        self.elf = ELFFile(io_bytes)
 
         self.modinfo_deps = None
         modinfo_secndx = self.elf.get_section_index('.modinfo')
@@ -33,4 +59,3 @@ class TargetModElf:
                     self.elf_syms[sym.name] = [sym]
                 else:
                     self.elf_syms[sym.name].append(sym)
-

--- a/rpm/klp-ccp.spec
+++ b/rpm/klp-ccp.spec
@@ -8,6 +8,7 @@ Group:		Development/Tools/Building
 Url:		https://github.com/SUSE/klp-ccp
 Source:	klp-ccp-%{version}.tar.gz
 Requires:	python313
+Requires:	python313-magic
 BuildRequires:	python313-devel
 BuildRequires:	make
 BuildRequires:	gcc-c++


### PR DESCRIPTION
These changes do not change how klp-ccp works, just handles kernel modules that are not compressed. It will still continue to work the uncompressed files as before.