### PR TITLE
ast_evaluate: fix integer overflow crash in expr_binop::_evaluate_cmp

### DIFF
--- a/ast_evaluate.cc
+++ b/ast_evaluate.cc
@@ -4565,10 +4565,35 @@ void expr_binop::_evaluate_cmp(const types::arithmetic_type &at_left,
 	 }
        },
        [&](const int_type &it) {
-	    // These don't overflow because the result type comes from
-	    // an arithmetic conversion.
-	    const target_int i_left = cv_left.convert_to(tgt, it);
-	    const target_int i_right = cv_right.convert_to(tgt, it);
+	    const mpa::limbs::size_type it_width = it.get_width(tgt);
+	    const bool it_is_signed = it.is_signed(tgt);
+
+	    auto convert_or_wrap =
+	      [&](const constexpr_value &cv) {
+		target_int result;
+		try {
+		  result = cv.convert_to(tgt, it);
+		} catch (const std::overflow_error&) {
+		  code_remark remark
+		    (code_remark::severity::warning,
+		     "integer overflow in implicit conversion for comparison",
+		     a.get_pp_result(), this->get_tokens_range());
+		  a.get_remarks().add(remark);
+		  // Do a wrapping bit-pattern conversion, consistent with
+		  // how GCC handles out-of-range implicit integer conversions.
+		  mpa::limbs ls = cv.get_int_value().get_limbs();
+		  ls.resize(mpa::limbs::width_to_size(it_width));
+		  ls.set_bits_at_and_above(it_width,
+					   it_is_signed &&
+					   ls.test_bit(it_width - 1));
+		  result = target_int(it_width - it_is_signed, it_is_signed,
+				      std::move(ls));
+		}
+		return result;
+	      };
+
+	    const target_int i_left = convert_or_wrap(cv_left);
+	    const target_int i_right = convert_or_wrap(cv_right);
 
 	    bool result;
 	    switch (_op) {


### PR DESCRIPTION
When evaluating a binary comparison between two integer constant expressions, _evaluate_cmp calls constexpr_value::convert_to() to convert both operands to the common type determined by the arithmetic conversions. The original code assumed this conversion could never overflow.

However, this guarantee holds only at the type level. The value stored in a constexpr_value may have been produced from a different original type than what arithmetic_conversion() used to compute the common type. If the constexpr_value holds an unsigned value with the high bit set and the common type is signed, convert_to() calls target_int::convert() with prec = width - 1, which detects the value does not fit in a signed type and throws std::overflow_error.

Since the overflow_error was not caught in _evaluate_cmp, it propagated through Bison's generated catch-all handler in gnuc_parser::parse(), which rethrew it. gnuc_parser_driver::parse() had no handler for std::overflow_error, so it escaped to std::terminate().

Fix this by wrapping both convert_to() calls in a try-catch that emits a warning and falls back to a wrapping bit-pattern conversion, consistent with GCC's behavior for out-of-range implicit integer conversions. This mirrors the existing pattern used for overflow in explicit casts (same file, expr_cast handler).

---

I managed to trigger this error. I suspect after commit https://github.com/torvalds/linux/commit/ee62ce7a1d909ccba0399680a03c2dee83bcae95 landed in our products branches.