### PR TITLE
Fix check on bison lookahead token

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,13 +19,13 @@ fi
 AC_CONFIG_HEADERS([config.h])
 
 bison_version=[`bison --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'`]
-AX_COMPARE_VERSION(["$bison_version"], [lt], ["3.0.4"],
+AX_COMPARE_VERSION(["$bison_version"], [lt], ["3.6"],
         [AC_SUBST([BISON_YYLA_HAS_TYPE], [1])],
         [AC_SUBST([BISON_YYLA_HAS_TYPE], [0])])
 
 AC_DEFINE_UNQUOTED([BISON_YYLA_HAS_TYPE], [$BISON_YYLA_HAS_TYPE],
-                   [Older versions of bison has .type entry in the lookahead
-                    token, which has been renamed to .kind_ in later versions])
+                   [Bison < 3.6 has a .type entry in the lookahead token,
+                    which was renamed to .kind_ in 3.6 (symbol_kind)])
 
 
 PKG_CHECK_MODULES([PYTHON3_EMBED], [python3-embed],

--- a/gnuc_parser.yy
+++ b/gnuc_parser.yy
@@ -2052,7 +2052,7 @@ iteration_statement:
 	    if (yyla.type_get() == by_type(token::TOK_IDENTIFIER).type_get()) {
 	      if (pd.is_typedef_id(pd._pp.get_result().get_pp_tokens()[yyla.value.token_index].get_value())) {
 		/*
-		 * On bison 3.0.4, yyla.type has been renamed to yyla.kind_
+		 * In bison 3.6, yyla.type was renamed to yyla.kind_
 		 */
 	#if BISON_YYLA_HAS_TYPE == 1
 		yyla.type = by_type(token::TOK_TYPEDEF_IDENTIFIER).type_get();


### PR DESCRIPTION
Before 3.6, .type was being used. In more recent versions .kind_ is used. This fixed a compilation issue on SLE 15.7 machine.